### PR TITLE
Fix deprecation warning

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -326,7 +326,8 @@ class ServerlessAWSResolvers {
         options: {
           key: {
             usage: 'The key to resolve',
-            shortcut: 'k'
+            shortcut: 'k',
+            type: 'string'
           }
         }
       }


### PR DESCRIPTION
This pull request fixes the following deprecation warning:
```
CLI options definitions were upgraded with "type" property (which could be one of "string", "boolean", "multiple"). Below listed plugins do not predefine type for introduced options:
 - ServerlessAWSResolvers for "key"
```